### PR TITLE
Gen-Tables  Include/Exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added EF Core table descriptor generation via `Gen-Tables ef`, including project-based metadata extraction.
 - Added opt-in schema-split table generation via `gentables --split-tables-by-schema`, placing descriptors in schema-specific folders and namespaces while preserving a global `AllTables` aggregate.
 - Added opt-in table-generation cleanup via `gentables --clean-output`, `Gen-Tables -CleanOutput`, and `SqEfTablesGenCleanOutput`, removing missing or stale recognized table descriptors while preserving unrelated code.
+- Added include and exclude filters with `*` and `?` wildcard support to database-first and EF table generation, available through the CLI, Package Manager Console, and EF MSBuild properties.
 - Added `BindTables(...)` and `TryBindTables(...)` for reconnecting parsed or deserialized AST table/column nodes to canonical table metadata, with configurable warning/error severity and partial-result support.
 - `SqTSqlParser` now emits alias-specific `SqTable` objects and reuses their owned `TableColumn` objects directly when parsing with an existing table list, avoiding a second AST rewrite and preserving exact table/column ownership.
 - Extended `TablesGraph.TryToJoinTables(...)` with greedy multi-table join-tree construction, automatically aliased connector tables, and configurable ambiguous-path handling through deterministic selection, failure, or a callback over all equal shortest paths.

--- a/Documentation/database_first_table_generation.md
+++ b/Documentation/database_first_table_generation.md
@@ -108,6 +108,20 @@ Gen-Tables mssql `
 
 Review every reported omission because the generated descriptor will not represent the complete table.
 
+Filter tables by physical schema and table name:
+
+```powershell
+Gen-Tables mssql `
+  -ConnectionString "<connection-string>" `
+  -Include "sales.*", "Customer?" `
+  -Exclude "*.OrderArchive*" `
+  -UseTableDeclarationAttributes
+```
+
+Patterns containing `.` match the complete `schema.table` name. Patterns without `.` match table names in every schema. Matching is case-insensitive; `*` matches zero or more characters and `?` matches exactly one character. When includes are supplied, a table must match at least one include. Excludes are applied afterward and always win.
+
+Foreign-key metadata pointing to a filtered-out table is omitted. With `-CleanOutput`, descriptor files for filtered-out tables are removed, so use cleanup only when the output directory is generator-owned.
+
 ## Schema Folders
 
 `-SplitTablesBySchema` creates a folder and namespace segment for each schema.
@@ -142,6 +156,8 @@ Keep cleanup disabled when the output directory contains table descriptors maint
 | `SkipUnknownColumnTypes` | no | `false` | Omits unsupported columns instead of failing. |
 | `SplitTablesBySchema` | no | `false` | Creates schema-specific folders and namespace segments. |
 | `CleanOutput` | no | project property `SqTablseGenCleanOutput`; otherwise `false` | Removes obsolete recognized descriptors after successful generation. |
+| `Include` | no | project property `SqTablseGenInclude`; otherwise all tables | One or more case-insensitive table patterns. Use `*` and `?`; qualify with `schema.` to restrict a pattern to a schema. |
+| `Exclude` | no | project property `SqTablseGenExclude`; otherwise none | One or more table patterns applied after includes. Excludes always win. |
 
 The `SqTablse...` spelling is retained for backward compatibility.
 
@@ -152,6 +168,8 @@ For scripts, CI, or environments without Visual Studio Package Manager Console, 
 ```powershell
 dotnet "<package>\tools\codegen\SqExpress.CodeGenUtil.dll" `
   gentables mssql "<connection-string>" `
+  --include "sales.*;Customer?" `
+  --exclude "*.OrderArchive*" `
   --use-table-declaration-attributes
 ```
 
@@ -171,7 +189,10 @@ For the pure CLI, a relative `--output-dir` path is resolved from the process's 
 | `--skip-unknown-column-types` | no | `false` | Omits unsupported columns instead of failing. |
 | `--split-tables-by-schema` | no | `false` | Creates schema-specific folders and namespace segments. |
 | `--clean-output` | no | `false` | Removes obsolete recognized descriptors after successful generation. |
+| `--include <patterns>` | no | all tables | Semicolon-separated case-insensitive include patterns supporting `*` and `?`. |
+| `--exclude <patterns>` | no | none | Semicolon-separated exclude patterns, applied after includes. |
 
 Boolean CLI options are switches: include the option to enable it and omit the option to keep its default value.
+Quote filter lists so the shell does not expand wildcard characters. Supply multiple patterns as a semicolon-separated list.
 
 For generation from an EF Core model, see [Entity Framework Table Generation](ef_table_generation.md).

--- a/Documentation/ef_table_generation.md
+++ b/Documentation/ef_table_generation.md
@@ -53,6 +53,8 @@ The following block shows the generation properties together. It is a reference,
   <SqEfTablesGenSkipUnknownColumnTypes>true</SqEfTablesGenSkipUnknownColumnTypes>
   <SqEfTablesGenSplitTablesBySchema>false</SqEfTablesGenSplitTablesBySchema>
   <SqEfTablesGenCleanOutput>false</SqEfTablesGenCleanOutput>
+  <SqEfTablesGenInclude></SqEfTablesGenInclude>
+  <SqEfTablesGenExclude></SqEfTablesGenExclude>
 </PropertyGroup>
 ```
 
@@ -69,6 +71,8 @@ The following block shows the generation properties together. It is a reference,
 | `SqEfTablesGenSkipUnknownColumnTypes` | `true` | Whether unsupported EF column types are reported and omitted instead of failing generation. | Set it to `false` when a partial descriptor is unsafe and every mapped column must be supported. Leave it `true` when unsupported columns may intentionally be excluded after reviewing diagnostics. |
 | `SqEfTablesGenSplitTablesBySchema` | `false` | Whether database schemas become output subdirectories and namespace segments. | Set it to `true` when the model uses multiple schemas, especially when schemas contain tables with the same name or the project is organized by schema. |
 | `SqEfTablesGenCleanOutput` | `false` | Whether obsolete recognized descriptors are removed after successful generation. | Set it to `true` when the output directory is generator-owned and should exactly follow the EF model. Leave it `false` if that directory also contains manually maintained descriptors. |
+| `SqEfTablesGenInclude` | empty | Semicolon-separated, case-insensitive table patterns to include. Empty includes every table. | Set it when only part of the EF relational model should produce descriptors. Use `*` and `?`, and qualify with `schema.` when needed. |
+| `SqEfTablesGenExclude` | empty | Semicolon-separated table patterns to exclude after includes. | Set it for archive, migration, or other tables that must never be generated. Excludes always win. |
 | `SqExpressCodeGenPath` | packaged tool path | The location of `SqExpress.CodeGenUtil.dll`. The package sets it automatically. | Change it only for source-tree development, custom package layouts, or controlled builds that intentionally use another code-generator binary. Application projects normally should not set it. |
 
 ## Selecting a `DbContext`
@@ -168,6 +172,19 @@ Cleanup runs only after metadata is read successfully. A file is deleted only wh
 
 Leave cleanup disabled when the directory contains descriptors maintained by hand.
 
+## Filtering Tables
+
+Generate only selected physical tables with include and exclude patterns:
+
+```xml
+<SqEfTablesGenInclude>sales.*;Customer?</SqEfTablesGenInclude>
+<SqEfTablesGenExclude>*.OrderArchive*</SqEfTablesGenExclude>
+```
+
+A pattern containing `.` matches the complete `schema.table` name; an unqualified pattern matches table names in every schema. Matching is case-insensitive. `*` matches zero or more characters and `?` matches exactly one character. A table must match an include when any includes are configured, then exclusions are applied and always win.
+
+Foreign-key metadata pointing to a filtered-out table is omitted. When `SqEfTablesGenCleanOutput` is enabled, files belonging to filtered-out tables are removed.
+
 ## Unsupported Column Types
 
 Unsupported columns are reported and omitted by default:
@@ -218,6 +235,8 @@ The project argument can be a Visual Studio project name or `.csproj` path. When
 | `SkipUnknownColumnTypes` | no | `false` | Omits unsupported columns instead of failing. |
 | `SplitTablesBySchema` | no | `false` | Creates schema-specific folders and namespaces. |
 | `CleanOutput` | no | project property `SqTablseGenCleanOutput`; otherwise `false` | Removes obsolete recognized descriptors. |
+| `Include` | no | project property `SqTablseGenInclude`; otherwise all tables | One or more wildcard include patterns. |
+| `Exclude` | no | project property `SqTablseGenExclude`; otherwise none | One or more wildcard exclude patterns; exclusions win. |
 
 The `SqTablse...` spelling is retained for backward compatibility.
 
@@ -228,6 +247,8 @@ For scripts or CI, invoke the utility included in the NuGet package:
 ```powershell
 dotnet "<package>\tools\codegen\SqExpress.CodeGenUtil.dll" `
   gentables ef ".\Data\MyApp.Data.csproj" `
+  --include "sales.*;Customer?" `
+  --exclude "*.OrderArchive*" `
   --use-table-declaration-attributes
 ```
 
@@ -249,7 +270,10 @@ For the pure CLI, a relative `--output-dir` path is resolved from the process's 
 | `--framework <tfm>` | no | automatic | Target framework. Required when it cannot be inferred unambiguously. |
 | `--split-tables-by-schema` | no | `false` | Creates schema-specific folders and namespaces. |
 | `--clean-output` | no | `false` | Removes obsolete recognized descriptors after successful generation. |
+| `--include <patterns>` | no | all tables | Semicolon-separated, case-insensitive include patterns supporting `*` and `?`. |
+| `--exclude <patterns>` | no | none | Semicolon-separated exclude patterns, applied after includes. |
 
 Boolean CLI options are switches: include the option to enable it and omit the option to retain its default.
+Quote filter lists so the shell does not expand wildcard characters. Supply multiple patterns as a semicolon-separated list.
 
 For generation from a live database, see [Database-First Table Generation](database_first_table_generation.md).

--- a/SqExpress.CodegenUtil/GenTablesOptions.cs
+++ b/SqExpress.CodegenUtil/GenTablesOptions.cs
@@ -1,11 +1,15 @@
-﻿using CommandLine;
+﻿using System;
+using CommandLine;
+
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SqExpress.CodeGenUtil
 {
     [Verb("gentables", HelpText = "Generate table descriptor classes.")]
     public class GenTablesOptions
     {
-        public GenTablesOptions(ConnectionType connectionType, string source, string tableClassPrefix, string outputDir, string @namespace, Verbosity verbosity, bool useTableDeclarationAttributes = false, bool skipUnknownColumnTypes = false, string dbContext = "", string framework = "", bool splitTablesBySchema = false, bool cleanOutput = false)
+        public GenTablesOptions(ConnectionType connectionType, string source, string tableClassPrefix, string outputDir, string @namespace, Verbosity verbosity, bool useTableDeclarationAttributes = false, bool skipUnknownColumnTypes = false, string dbContext = "", string framework = "", bool splitTablesBySchema = false, bool cleanOutput = false, IEnumerable<string>? include = null, IEnumerable<string>? exclude = null)
         {
             this.ConnectionType = connectionType;
             this.Source = source;
@@ -19,6 +23,8 @@ namespace SqExpress.CodeGenUtil
             this.Framework = framework;
             this.SplitTablesBySchema = splitTablesBySchema;
             this.CleanOutput = cleanOutput;
+            this.Include = include?.ToArray() ?? Array.Empty<string>();
+            this.Exclude = exclude?.ToArray() ?? Array.Empty<string>();
         }
 
         [Value(1, MetaName = "CONNECTION_TYPE", Required = true, HelpText = "Connection Type: \"mssql\" or \"mysql\" or \"pgsql\" or \"ef\".")]
@@ -56,6 +62,12 @@ namespace SqExpress.CodeGenUtil
 
         [Option("clean-output", Required = false, Default = false, HelpText = "Remove obsolete table descriptors from the output directory.")]
         public bool CleanOutput { get; }
+
+        [Option("include", Required = false, Separator = ';', HelpText = "Include tables matching a semicolon-separated list of wildcard patterns.")]
+        public IEnumerable<string> Include { get; }
+
+        [Option("exclude", Required = false, Separator = ';', HelpText = "Exclude tables matching a semicolon-separated list of wildcard patterns.")]
+        public IEnumerable<string> Exclude { get; }
     }
 
     public enum ConnectionType

--- a/SqExpress.CodegenUtil/Program.cs
+++ b/SqExpress.CodegenUtil/Program.cs
@@ -127,6 +127,8 @@ namespace SqExpress.CodeGenUtil
                 tables = await sqlManager.SelectTables(options.SkipUnknownColumnTypes);
             }
 
+            tables = TableFilter.Apply(tables, options.Include, options.Exclude);
+
             if(logger.IsNormalOrHigher)
             {
                 logger.LogNormal(tables.Count > 0

--- a/SqExpress.CodegenUtil/TableFilter.cs
+++ b/SqExpress.CodegenUtil/TableFilter.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using SqExpress.DbMetadata.Internal.Model;
+
+namespace SqExpress.CodeGenUtil
+{
+    internal static class TableFilter
+    {
+        public static IReadOnlyList<TableModel> Apply(
+            IReadOnlyList<TableModel> tables,
+            IEnumerable<string> includes,
+            IEnumerable<string> excludes)
+        {
+            var includePatterns = CompilePatterns(includes, "include");
+            var excludePatterns = CompilePatterns(excludes, "exclude");
+
+            var selected = tables.Where(table =>
+                    (includePatterns.Count == 0 || includePatterns.Any(pattern => pattern.IsMatch(table))) &&
+                    !excludePatterns.Any(pattern => pattern.IsMatch(table)))
+                .ToList();
+
+            var selectedTables = selected
+                .Select(static table => QualifiedName(table.DbName))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            return selected.Select(table => WithoutExternalForeignKeys(table, selectedTables)).ToList();
+        }
+
+        private static IReadOnlyList<TablePattern> CompilePatterns(IEnumerable<string> patterns, string optionName)
+        {
+            var result = new List<TablePattern>();
+            foreach (var pattern in patterns)
+            {
+                if (string.IsNullOrWhiteSpace(pattern))
+                {
+                    throw new SqExpressCodeGenException($"Table {optionName} pattern cannot be empty.");
+                }
+
+                result.Add(new TablePattern(pattern));
+            }
+
+            return result;
+        }
+
+        private static TableModel WithoutExternalForeignKeys(TableModel table, ISet<string> selectedTables)
+        {
+            var columns = table.Columns.Select(column =>
+            {
+                var foreignKeys = column.Fk?
+                    .Where(foreignKey => selectedTables.Contains(QualifiedName(foreignKey.Table)))
+                    .ToList();
+
+                return new ColumnModel(
+                    column.Name,
+                    column.DbName,
+                    column.OrdinalPosition,
+                    column.ColumnType,
+                    column.Pk,
+                    column.Identity,
+                    column.DefaultValue,
+                    foreignKeys?.Count > 0 ? foreignKeys : null);
+            }).ToList();
+
+            return new TableModel(table.Name, table.DbName, columns, table.Indexes);
+        }
+
+        private static string QualifiedName(TableRef table) => $"{table.Schema}.{table.Name}";
+
+        private sealed class TablePattern
+        {
+            private readonly Regex regex;
+            private readonly bool qualified;
+
+            public TablePattern(string pattern)
+            {
+                this.qualified = pattern.Contains('.');
+                var regexPattern = Regex.Escape(pattern)
+                    .Replace("\\*", ".*")
+                    .Replace("\\?", ".");
+                this.regex = new Regex(
+                    "^" + regexPattern + "$",
+                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            }
+
+            public bool IsMatch(TableModel table) =>
+                this.regex.IsMatch(this.qualified ? QualifiedName(table.DbName) : table.DbName.Name);
+        }
+    }
+}

--- a/SqExpress/PsTools/SqExpressTools.psm1
+++ b/SqExpress/PsTools/SqExpressTools.psm1
@@ -18,7 +18,9 @@ function Gen-Tables
         [switch] $UseTableDeclarationAttributes,
         [switch] $SkipUnknownColumnTypes,
         [switch] $SplitTablesBySchema,
-        [switch] $CleanOutput
+        [switch] $CleanOutput,
+        [string[]] $Include,
+        [string[]] $Exclude
     )
 	
     if($DbType -eq 'ef')
@@ -106,6 +108,26 @@ function Gen-Tables
     if($CleanOutput.IsPresent -or (GetCurrentProjectProperty "SqTablseGenCleanOutput") -eq "True")
     {
         $args = $args + " --clean-output"
+    }
+
+    if(!$Include)
+    {
+        $includeProperty = GetCurrentProjectProperty "SqTablseGenInclude"
+        if($includeProperty) { $Include = $includeProperty }
+    }
+    if($Include)
+    {
+        $args = $args + " --include """ + ($Include -join ';') + """"
+    }
+
+    if(!$Exclude)
+    {
+        $excludeProperty = GetCurrentProjectProperty "SqTablseGenExclude"
+        if($excludeProperty) { $Exclude = $excludeProperty }
+    }
+    if($Exclude)
+    {
+        $args = $args + " --exclude """ + ($Exclude -join ';') + """"
     }
 
     if($DbType -eq 'ef' -and $DbContext)

--- a/SqExpress/SqExpress.props
+++ b/SqExpress/SqExpress.props
@@ -10,6 +10,8 @@
     <SqTablseGenNamespace>$(MSBuildProjectName).Tables</SqTablseGenNamespace>
     <SqTablseGenTableClassPrefix></SqTablseGenTableClassPrefix>
     <SqTablseGenCleanOutput>false</SqTablseGenCleanOutput>
+    <SqTablseGenInclude></SqTablseGenInclude>
+    <SqTablseGenExclude></SqTablseGenExclude>
     <SqExpressCodeGenPath>$(MSBuildThisFileDirectory)../tools/codegen/SqExpress.CodeGenUtil.dll</SqExpressCodeGenPath>
     <SqEfTablesGenEnable>false</SqEfTablesGenEnable>
     <SqEfTablesGenProject></SqEfTablesGenProject>
@@ -22,5 +24,7 @@
     <SqEfTablesGenSkipUnknownColumnTypes>true</SqEfTablesGenSkipUnknownColumnTypes>
     <SqEfTablesGenSplitTablesBySchema>false</SqEfTablesGenSplitTablesBySchema>
     <SqEfTablesGenCleanOutput>false</SqEfTablesGenCleanOutput>
+    <SqEfTablesGenInclude></SqEfTablesGenInclude>
+    <SqEfTablesGenExclude></SqEfTablesGenExclude>
   </PropertyGroup>
 </Project>

--- a/SqExpress/SqExpress.targets
+++ b/SqExpress/SqExpress.targets
@@ -52,12 +52,16 @@
       <SqEfTablesGenSplitTablesBySchemaParam Condition="'$(SqEfTablesGenSplitTablesBySchema)'!='True' And '$(SqEfTablesGenSplitTablesBySchema)'!='true'"></SqEfTablesGenSplitTablesBySchemaParam>
       <SqEfTablesGenCleanOutputParam Condition="'$(SqEfTablesGenCleanOutput)'=='True' Or '$(SqEfTablesGenCleanOutput)'=='true'"> --clean-output</SqEfTablesGenCleanOutputParam>
       <SqEfTablesGenCleanOutputParam Condition="'$(SqEfTablesGenCleanOutput)'!='True' And '$(SqEfTablesGenCleanOutput)'!='true'"></SqEfTablesGenCleanOutputParam>
+      <SqEfTablesGenIncludeParam Condition="'$(SqEfTablesGenInclude)' != ''"> --include &quot;$(SqEfTablesGenInclude)&quot;</SqEfTablesGenIncludeParam>
+      <SqEfTablesGenIncludeParam Condition="'$(SqEfTablesGenInclude)' == ''"></SqEfTablesGenIncludeParam>
+      <SqEfTablesGenExcludeParam Condition="'$(SqEfTablesGenExclude)' != ''"> --exclude &quot;$(SqEfTablesGenExclude)&quot;</SqEfTablesGenExcludeParam>
+      <SqEfTablesGenExcludeParam Condition="'$(SqEfTablesGenExclude)' == ''"></SqEfTablesGenExcludeParam>
     </PropertyGroup>
     <ItemGroup>
       <Compile Remove="$(SqEfTablesGenOutput)\**\*.cs" />
     </ItemGroup>
     <Exec
-      Command="dotnet &quot;$(SqExpressCodeGenPath)&quot; gentables ef &quot;$(SqEfTablesGenSource)&quot; -o &quot;$(SqEfTablesGenOutput)&quot; -n &quot;$(SqEfTablesGenNamespace)&quot; -v quiet$(SqEfTablesGenFrameworkParam)$(SqEfTablesGenTableClassPrefixParam)$(SqEfTablesGenDbContextParam)$(SqEfTablesGenUseTableDeclarationAttributesParam)$(SqEfTablesGenSkipUnknownColumnTypesParam)$(SqEfTablesGenSplitTablesBySchemaParam)$(SqEfTablesGenCleanOutputParam)"
+      Command="dotnet &quot;$(SqExpressCodeGenPath)&quot; gentables ef &quot;$(SqEfTablesGenSource)&quot; -o &quot;$(SqEfTablesGenOutput)&quot; -n &quot;$(SqEfTablesGenNamespace)&quot; -v quiet$(SqEfTablesGenFrameworkParam)$(SqEfTablesGenTableClassPrefixParam)$(SqEfTablesGenDbContextParam)$(SqEfTablesGenUseTableDeclarationAttributesParam)$(SqEfTablesGenSkipUnknownColumnTypesParam)$(SqEfTablesGenSplitTablesBySchemaParam)$(SqEfTablesGenCleanOutputParam)$(SqEfTablesGenIncludeParam)$(SqEfTablesGenExcludeParam)"
       WorkingDirectory="$(MSBuildProjectDirectory)"
       ConsoleToMSBuild="true"
       StandardOutputImportance="Low"

--- a/Test/SqExpress.Test/CodeGenUtil/TableFilterTest.cs
+++ b/Test/SqExpress.Test/CodeGenUtil/TableFilterTest.cs
@@ -1,0 +1,114 @@
+#if NET
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using SqExpress.CodeGenUtil;
+using SqExpress.DbMetadata.Internal.Model;
+
+namespace SqExpress.Test.CodeGenUtil
+{
+    [TestFixture]
+    public class TableFilterTest
+    {
+        [Test]
+        public void IncludeAndExcludePatternsFilterPhysicalTableNames()
+        {
+            var tables = new[]
+            {
+                Table("sales", "Order"),
+                Table("sales", "OrderArchive1"),
+                Table("dbo", "Order"),
+                Table("dbo", "Customer")
+            };
+
+            var result = TableFilter.Apply(
+                tables,
+                new[] { "sales.*", "Customer" },
+                new[] { "*.OrderArchive?" });
+
+            Assert.That(result.Select(static table => table.DbName.ToString()),
+                Is.EqualTo(new[] { "sales.Order", "dbo.Customer" }));
+        }
+
+        [Test]
+        public void MatchingIsCaseInsensitiveAndRegexCharactersAreLiteral()
+        {
+            var tables = new[]
+            {
+                Table("dbo", "Audit.Log"),
+                Table("dbo", "AuditXLog")
+            };
+
+            var result = TableFilter.Apply(tables, new[] { "DBO.AUDIT.LOG" }, new string[0]);
+
+            Assert.That(result.Single().DbName.Name, Is.EqualTo("Audit.Log"));
+        }
+
+        [Test]
+        public void ExcludeWinsOverInclude()
+        {
+            var result = TableFilter.Apply(
+                new[] { Table("dbo", "Customer") },
+                new[] { "Customer" },
+                new[] { "Cust*" });
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void ForeignKeysToFilteredTablesAreRemoved()
+        {
+            var customer = Table("dbo", "Customer");
+            var order = Table(
+                "dbo",
+                "Order",
+                new ColumnModel(
+                    "CustomerId",
+                    new ColumnRef("dbo", "Order", "CustomerId"),
+                    0,
+                    new Int32ColumnType(false),
+                    null,
+                    false,
+                    null,
+                    new List<ColumnRef> { new ColumnRef("dbo", "Customer", "Id") }));
+
+            var result = TableFilter.Apply(new[] { customer, order }, new[] { "Order" }, new string[0]);
+
+            Assert.That(result.Single().Columns.Single().Fk, Is.Null);
+            Assert.That(order.Columns.Single().Fk, Has.Count.EqualTo(1), "Source metadata must not be mutated.");
+        }
+
+        [Test]
+        public void ForeignKeysWithinSelectionArePreserved()
+        {
+            var customer = Table("dbo", "Customer");
+            var order = Table(
+                "dbo",
+                "Order",
+                new ColumnModel(
+                    "CustomerId",
+                    new ColumnRef("dbo", "Order", "CustomerId"),
+                    0,
+                    new Int32ColumnType(false),
+                    null,
+                    false,
+                    null,
+                    new List<ColumnRef> { new ColumnRef("dbo", "Customer", "Id") }));
+
+            var result = TableFilter.Apply(new[] { customer, order }, new[] { "dbo.*" }, new string[0]);
+
+            Assert.That(result.Single(table => table.DbName.Name == "Order").Columns.Single().Fk, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public void EmptyPatternIsRejected()
+        {
+            Assert.Throws<SqExpressCodeGenException>(() =>
+                TableFilter.Apply(new[] { Table("dbo", "Customer") }, new[] { " " }, new string[0]));
+        }
+
+        private static TableModel Table(string schema, string name, params ColumnModel[] columns) =>
+            new TableModel("Table" + name, new TableRef(schema, name), columns.ToList(), new List<IndexModel>());
+    }
+}
+#endif


### PR DESCRIPTION
Add include/exclude table filters with * and ? wildcard support across CLI, PMC, and EF MSBuild generation. Filtered foreign keys and obsolete outputs are handled correctly, with tests, documentation, and changelog updates included.